### PR TITLE
Fix some typos

### DIFF
--- a/english/10.Developers/HOWTO-package-OCS-Unix-agent-releases.md
+++ b/english/10.Developers/HOWTO-package-OCS-Unix-agent-releases.md
@@ -6,21 +6,21 @@ To package the OCS Unix server release, we will use git to get code from GitHub.
 
 Now, get the Ocsinventory Unix agent code from Launchpad using this command :
 
-    $git clone https://github.com/OCSInventory-NG/UnixAgent
-    $cd UnixAgent
+    $ git clone https://github.com/OCSInventory-NG/UnixAgent
+    $ cd UnixAgent
 
 ## Create the tarball file
 
 Create the release tarball using this commands:
 
-    $rm MANIFEST
-    $perl Makefile.PL
+    $ rm MANIFEST
+    $ perl Makefile.PL
 
 **`Warning`**`: If you are under Linux, you have to delete the ipdiscover binary before launching the next
 commands. Delete the ipdiscover binary using this command: rm ipdiscover.`**
 
-    $make manifest
-    $make dist
+    $ make manifest
+    $ make dist
 
-The last command creates automatically the release tarball file named Ocsinventory-Agent-XXX.tar.gz
+The last command creates automatically the release tarball file named Ocsinventory-Unix-Agent-XXX.tar.gz
 in the current directory.


### PR DESCRIPTION
Add spaces behind each command and the name of the archive is Ocsinventory-Unix-Agent-XXX.tar.gz