### PR TITLE
apt-key deprecated

### DIFF
--- a/english/03.Basic-documentation/Setting-up-the-UNIX-agent-using-repository-on-client-computers.md
+++ b/english/03.Basic-documentation/Setting-up-the-UNIX-agent-using-repository-on-client-computers.md
@@ -28,7 +28,7 @@ Then install the agent using :
 
 You need to add our repository using the following command
 
-    $ curl -sS http://deb.ocsinventory-ng.org/pubkey.gpg | sudo apt-key add -
+    $ curl -fsSL http://deb.ocsinventory-ng.org/pubkey.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/ocs-archive-keyring.gpg
     $ echo "deb http://deb.ocsinventory-ng.org/ubuntu/ <distribution_codename> main" | sudo tee /etc/apt/sources.list.d/ocsinventory.list
     $ sudo apt update
 

--- a/english/03.Basic-documentation/Setting-up-the-UNIX-agent-using-repository-on-client-computers.md
+++ b/english/03.Basic-documentation/Setting-up-the-UNIX-agent-using-repository-on-client-computers.md
@@ -26,9 +26,17 @@ Then install the agent using :
 
 **On Ubuntu-based distributions** you can install the agent with APT
 
-You need to add our repository using the following command
+You need to add our repository using the following commands :
+
+    $ curl -sS http://deb.ocsinventory-ng.org/pubkey.gpg | sudo apt-key add -
+
+**Note** : apt-key is now deprecated as of Ubuntu 22.04, and will issue a warning. We recommend using the below gpg alternative :
+
 
     $ curl -fsSL http://deb.ocsinventory-ng.org/pubkey.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/ocs-archive-keyring.gpg
+
+Then : 
+  
     $ echo "deb http://deb.ocsinventory-ng.org/ubuntu/ <distribution_codename> main" | sudo tee /etc/apt/sources.list.d/ocsinventory.list
     $ sudo apt update
 


### PR DESCRIPTION
apt-key is deprecated in ubuntu 22.04, use gpg instead