### PR TITLE
typo(restapi): fix misleading sentence for API rest routes

### DIFF
--- a/english/11.Rest-API/Authentification.md
+++ b/english/11.Rest-API/Authentification.md
@@ -6,5 +6,5 @@ You need to add your restrictions in the `<Location /ocsapi></Location>`. You ca
 
 In the future we plan to use a restful process and stop rely on apache configuration.
 
-By default, the API can be access trough : 
-`http://myocsserver/ocsapi/v1/my/routes`
+By default, the API base URI is the following one : 
+`http://myocsserver/ocsapi/v1`

--- a/english/11.Rest-API/GET-Routes.md
+++ b/english/11.Rest-API/GET-Routes.md
@@ -1,7 +1,7 @@
 # GET Routes
 
-By default, the API can be access trough : 
-`http://myocsserver/ocsapi/v1/my/routes`
+By default, the API root URI is the following one : 
+`http://myocsserver/ocsapi/v1`
 
 ## Computers Routes
 


### PR DESCRIPTION
typo(restapi): fix misleading sentence for API rest routes